### PR TITLE
Add Nix dependancies shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+in
+with nixpkgs; stdenv.mkDerivation {
+    name = "moz_overlay_shell";
+    buildInputs = [ 
+        nixpkgs.latest.rustChannels.stable.rust
+        SDL2 
+        SDL2_ttf 
+        SDL2_gfx
+    ];
+}


### PR DESCRIPTION
The SDL2 dependancies need to be installed on the system. The Nix package manager (https://nixos.org/nix/) provides a nice cross-platform way to manage these, and further, dependencies.

Using `nix-shell` in the project root, the dependencies will be downloaded, including Rust if it is not already installed. You'll then be entered into a reproducible shell environment. The dependencies are defined in the `shell.nix` file committed in this PR.